### PR TITLE
Add Transit Gateway (TGW) integration support

### DIFF
--- a/src/data.tf
+++ b/src/data.tf
@@ -1,0 +1,13 @@
+# Data source to automatically lookup available Availability Zones in TGW mode
+# Only used when availability_zone_ids is not explicitly provided
+data "aws_availability_zones" "available" {
+  count = local.enabled && local.is_tgw_mode && length(var.availability_zone_ids) == 0 ? 1 : 0
+
+  state = "available"
+
+  # Filter out local zones (they don't have zone IDs in the same format)
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -41,7 +41,7 @@ locals {
 
 module "network_firewall" {
   source  = "cloudposse/network-firewall/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   # VPC mode: attach firewall to VPC subnets
   # Either 'vpc_id' or 'transit_gateway_id' must be provided, but not both
@@ -49,7 +49,9 @@ module "network_firewall" {
   subnet_ids = local.is_vpc_mode ? local.firewall_subnet_ids : []
 
   # Transit Gateway mode: attach firewall directly to Transit Gateway
-  transit_gateway_id = local.transit_gateway_id
+  # Uses availability_zone_ids instead of subnet_ids
+  transit_gateway_id   = local.transit_gateway_id
+  availability_zone_ids = local.is_tgw_mode ? var.availability_zone_ids : []
 
   network_firewall_name                     = var.network_firewall_name
   network_firewall_description              = var.network_firewall_description

--- a/src/main.tf
+++ b/src/main.tf
@@ -30,7 +30,7 @@ locals {
     }
   } : {}
 
-  # VPC-specific outputs (only used in VPC mode
+  # VPC-specific outputs (only used in VPC mode)
   vpc_outputs         = local.is_vpc_mode ? module.vpc.outputs : {}
   firewall_subnet_ids = local.is_vpc_mode ? try(local.vpc_outputs.named_private_subnets_map[var.firewall_subnet_name], []) : []
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,6 +2,14 @@ locals {
   enabled         = module.this.enabled
   logging_enabled = local.enabled && var.logging_enabled
 
+  # Determine deployment mode
+  # Either 'vpc' or 'transit_gateway' based on which component name is provided
+  is_vpc_mode = var.vpc_component_name != null && var.vpc_component_name != ""
+  is_tgw_mode = var.transit_gateway_component_name != null && var.transit_gateway_component_name != ""
+
+  # Validate that exactly one deployment mode is specified
+  deployment_mode_valid = local.is_vpc_mode != local.is_tgw_mode
+
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_logging_configuration
   logging_config = local.logging_enabled ? {
     flow = {
@@ -22,16 +30,26 @@ locals {
     }
   } : {}
 
-  vpc_outputs         = module.vpc.outputs
-  firewall_subnet_ids = local.vpc_outputs.named_private_subnets_map[var.firewall_subnet_name]
+  # VPC-specific outputs (only used in VPC mode)
+  vpc_outputs         = local.is_vpc_mode ? module.vpc.outputs : {}
+  firewall_subnet_ids = local.is_vpc_mode ? local.vpc_outputs.named_private_subnets_map[var.firewall_subnet_name] : []
+
+  # Transit Gateway-specific outputs (only used in TGW mode)
+  transit_gateway_outputs = local.is_tgw_mode ? module.transit_gateway.outputs : {}
+  transit_gateway_id      = local.is_tgw_mode ? local.transit_gateway_outputs.transit_gateway_id : null
 }
 
 module "network_firewall" {
   source  = "cloudposse/network-firewall/aws"
   version = "1.0.0"
 
-  vpc_id     = local.vpc_outputs.vpc_id
-  subnet_ids = local.firewall_subnet_ids
+  # VPC mode: attach firewall to VPC subnets
+  # Either 'vpc_id' or 'transit_gateway_id' must be provided, but not both
+  vpc_id     = local.is_vpc_mode ? local.vpc_outputs.vpc_id : null
+  subnet_ids = local.is_vpc_mode ? local.firewall_subnet_ids : []
+
+  # Transit Gateway mode: attach firewall directly to Transit Gateway
+  transit_gateway_id = local.transit_gateway_id
 
   network_firewall_name                     = var.network_firewall_name
   network_firewall_description              = var.network_firewall_description

--- a/src/main.tf
+++ b/src/main.tf
@@ -32,11 +32,11 @@ locals {
 
   # VPC-specific outputs (only used in VPC mode)
   vpc_outputs         = local.is_vpc_mode ? module.vpc.outputs : {}
-  firewall_subnet_ids = local.is_vpc_mode ? local.vpc_outputs.named_private_subnets_map[var.firewall_subnet_name] : []
+  firewall_subnet_ids = local.is_vpc_mode ? try(local.vpc_outputs.named_private_subnets_map[var.firewall_subnet_name], []) : []
 
   # Transit Gateway-specific outputs (only used in TGW mode)
   transit_gateway_outputs = local.is_tgw_mode ? module.transit_gateway.outputs : {}
-  transit_gateway_id      = local.is_tgw_mode ? local.transit_gateway_outputs.transit_gateway_id : null
+  transit_gateway_id      = local.is_tgw_mode ? try(local.transit_gateway_outputs.transit_gateway_id, null) : null
 }
 
 module "network_firewall" {

--- a/src/main.tf
+++ b/src/main.tf
@@ -28,7 +28,7 @@ locals {
 
 module "network_firewall" {
   source  = "cloudposse/network-firewall/aws"
-  version = "0.3.2"
+  version = "1.0.0"
 
   vpc_id     = local.vpc_outputs.vpc_id
   subnet_ids = local.firewall_subnet_ids

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -24,6 +24,16 @@ output "network_firewall_policy_arn" {
 }
 
 output "az_subnet_endpoint_stats" {
-  description = "List of objects with each object having three items: AZ, subnet ID, VPC endpoint ID"
+  description = "List of objects with each object having three items: AZ, subnet ID, VPC endpoint ID. Only applicable in VPC mode"
   value       = module.network_firewall.az_subnet_endpoint_stats
+}
+
+output "transit_gateway_attachment_id" {
+  description = "The unique identifier of the transit gateway attachment. Only applicable in Transit Gateway mode"
+  value       = module.network_firewall.transit_gateway_attachment_id
+}
+
+output "transit_gateway_owner_account_id" {
+  description = "The AWS account ID that owns the transit gateway. Only applicable in Transit Gateway mode"
+  value       = module.network_firewall.transit_gateway_owner_account_id
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -7,8 +7,8 @@ module "vpc" {
   bypass = var.vpc_component_name == null || var.vpc_component_name == ""
 
   defaults = {
-    vpc_id                      = ""
-    named_private_subnets_map   = {}
+    vpc_id                    = ""
+    named_private_subnets_map = {}
   }
 
   context = module.this.context

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -4,7 +4,8 @@ module "vpc" {
 
   component = var.vpc_component_name
 
-  bypass = var.vpc_component_name == null || var.vpc_component_name == ""
+  # Only load VPC remote state in VPC mode
+  bypass = !local.is_vpc_mode
 
   defaults = {
     vpc_id                    = ""
@@ -20,7 +21,8 @@ module "transit_gateway" {
 
   component = var.transit_gateway_component_name
 
-  bypass = var.transit_gateway_component_name == null || var.transit_gateway_component_name == ""
+  # Only load Transit Gateway remote state in TGW mode
+  bypass = !local.is_tgw_mode
 
   defaults = {
     transit_gateway_id  = ""

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -4,6 +4,29 @@ module "vpc" {
 
   component = var.vpc_component_name
 
+  bypass = var.vpc_component_name == null || var.vpc_component_name == ""
+
+  defaults = {
+    vpc_id                      = ""
+    named_private_subnets_map   = {}
+  }
+
+  context = module.this.context
+}
+
+module "transit_gateway" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.8.0"
+
+  component = var.transit_gateway_component_name
+
+  bypass = var.transit_gateway_component_name == null || var.transit_gateway_component_name == ""
+
+  defaults = {
+    transit_gateway_id  = ""
+    transit_gateway_arn = ""
+  }
+
   context = module.this.context
 }
 

--- a/src/validation.tf
+++ b/src/validation.tf
@@ -14,8 +14,8 @@ resource "null_resource" "validate_deployment_mode" {
     }
 
     precondition {
-      condition     = !local.is_vpc_mode || contains(keys(local.vpc_outputs.named_private_subnets_map), var.firewall_subnet_name)
-      error_message = "When using VPC mode, the 'firewall_subnet_name' (${var.firewall_subnet_name}) must exist in the VPC component's named_private_subnets_map. Available subnet names: ${join(", ", keys(local.vpc_outputs.named_private_subnets_map))}"
+      condition     = !local.is_vpc_mode || try(contains(keys(local.vpc_outputs.named_private_subnets_map), var.firewall_subnet_name), false)
+      error_message = "When using VPC mode, the 'firewall_subnet_name' (${var.firewall_subnet_name}) must exist in the VPC component's named_private_subnets_map. Available subnet names: ${try(join(", ", keys(local.vpc_outputs.named_private_subnets_map)), "none")}"
     }
 
     precondition {

--- a/src/validation.tf
+++ b/src/validation.tf
@@ -17,5 +17,10 @@ resource "null_resource" "validate_deployment_mode" {
       condition     = !local.is_tgw_mode || var.firewall_subnet_name == "firewall"
       error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'firewall_subnet_name' is not used and should be left at default."
     }
+
+    precondition {
+      condition     = !local.is_tgw_mode || length(var.availability_zone_ids) > 0
+      error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'availability_zone_ids' must be provided and cannot be empty."
+    }
   }
 }

--- a/src/validation.tf
+++ b/src/validation.tf
@@ -14,6 +14,11 @@ resource "null_resource" "validate_deployment_mode" {
     }
 
     precondition {
+      condition     = !local.is_vpc_mode || contains(keys(local.vpc_outputs.named_private_subnets_map), var.firewall_subnet_name)
+      error_message = "When using VPC mode, the 'firewall_subnet_name' (${var.firewall_subnet_name}) must exist in the VPC component's named_private_subnets_map. Available subnet names: ${join(", ", keys(local.vpc_outputs.named_private_subnets_map))}"
+    }
+
+    precondition {
       condition     = !local.is_tgw_mode || var.firewall_subnet_name == "firewall"
       error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'firewall_subnet_name' is not used and should be left at default."
     }

--- a/src/validation.tf
+++ b/src/validation.tf
@@ -24,8 +24,8 @@ resource "null_resource" "validate_deployment_mode" {
     }
 
     precondition {
-      condition     = !local.is_tgw_mode || length(var.availability_zone_ids) > 0
-      error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'availability_zone_ids' must be provided and cannot be empty."
+      condition     = !local.is_tgw_mode || length(local.availability_zone_ids) > 0
+      error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'availability_zone_ids' must be provided or available AZs must be auto-detected. Failed to determine Availability Zones."
     }
   }
 }

--- a/src/validation.tf
+++ b/src/validation.tf
@@ -19,11 +19,6 @@ resource "null_resource" "validate_deployment_mode" {
     }
 
     precondition {
-      condition     = !local.is_tgw_mode || var.firewall_subnet_name == "firewall"
-      error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'firewall_subnet_name' is not used and should be left at default."
-    }
-
-    precondition {
       condition     = !local.is_tgw_mode || length(local.availability_zone_ids) > 0
       error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'availability_zone_ids' must be provided or available AZs must be auto-detected. Failed to determine Availability Zones."
     }

--- a/src/validation.tf
+++ b/src/validation.tf
@@ -1,0 +1,21 @@
+# Validation: Ensure exactly one deployment mode is specified
+resource "null_resource" "validate_deployment_mode" {
+  count = local.enabled ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = local.deployment_mode_valid
+      error_message = "Exactly one of 'vpc_component_name' or 'transit_gateway_component_name' must be provided, not both or neither."
+    }
+
+    precondition {
+      condition     = !local.is_vpc_mode || (var.firewall_subnet_name != null && var.firewall_subnet_name != "")
+      error_message = "When using VPC mode (vpc_component_name is set), 'firewall_subnet_name' must be provided."
+    }
+
+    precondition {
+      condition     = !local.is_tgw_mode || var.firewall_subnet_name == "firewall"
+      error_message = "When using Transit Gateway mode (transit_gateway_component_name is set), 'firewall_subnet_name' is not used and should be left at default."
+    }
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -137,14 +137,3 @@ variable "availability_zone_ids" {
     error_message = "Each availability_zone_id must be in the format like 'use1-az1', 'usw2-az2', etc."
   }
 }
-
-variable "deployment_mode" {
-  type        = string
-  description = "Deployment mode for the Network Firewall. Valid values: 'vpc' or 'transit_gateway'"
-  default     = null
-
-  validation {
-    condition     = var.deployment_mode == null || contains(["vpc", "transit_gateway"], var.deployment_mode)
-    error_message = "The deployment_mode must be either 'vpc' or 'transit_gateway'."
-  }
-}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -119,6 +119,17 @@ variable "firewall_subnet_name" {
   default     = "firewall"
 }
 
+variable "availability_zone_ids" {
+  type        = list(string)
+  description = "List of Availability Zone IDs where firewall endpoints will be created for a transit gateway-attached firewall. Required when using 'transit_gateway_component_name', not used when using 'vpc_component_name'"
+  default     = []
+
+  validation {
+    condition     = length(var.availability_zone_ids) == 0 || alltrue([for az in var.availability_zone_ids : can(regex("^[a-z]{2,3}-[a-z]+-[0-9][a-z]$", az))])
+    error_message = "Each availability_zone_id must be in the format like 'use1-az1', 'usw2-az2', etc."
+  }
+}
+
 variable "deployment_mode" {
   type        = string
   description = "Deployment mode for the Network Firewall. Valid values: 'vpc' or 'transit_gateway'"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -121,7 +121,15 @@ variable "firewall_subnet_name" {
 
 variable "availability_zone_ids" {
   type        = list(string)
-  description = "List of Availability Zone IDs where firewall endpoints will be created for a transit gateway-attached firewall. Required when using 'transit_gateway_component_name', not used when using 'vpc_component_name'"
+  description = <<-EOT
+    List of Availability Zone IDs where firewall endpoints will be created for a transit gateway-attached firewall.
+    Only used when 'transit_gateway_component_name' is set, not used when using 'vpc_component_name'.
+
+    If not specified (empty list), all available AZs in the region will be automatically selected.
+    If specified, must use AZ ID format (e.g., 'use1-az1', 'usw2-az2'), not AZ names (e.g., 'us-east-1a').
+
+    Example: ["use1-az1", "use1-az2"]
+    EOT
   default     = []
 
   validation {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -133,7 +133,7 @@ variable "availability_zone_ids" {
   default     = []
 
   validation {
-    condition     = length(var.availability_zone_ids) == 0 || alltrue([for az in var.availability_zone_ids : can(regex("^[a-z]{2,3}-[a-z]+-[0-9][a-z]$", az))])
+    condition     = length(var.availability_zone_ids) == 0 || alltrue([for az in var.availability_zone_ids : can(regex("^[a-z]+[0-9]+-az[0-9]+[a-z]?$", az))])
     error_message = "Each availability_zone_id must be in the format like 'use1-az1', 'usw2-az2', etc."
   }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -5,7 +5,19 @@ variable "region" {
 
 variable "vpc_component_name" {
   type        = string
-  description = "The name of a VPC component where the Network Firewall is provisioned"
+  description = "The name of a VPC component where the Network Firewall is provisioned. Either 'vpc_component_name' or 'transit_gateway_component_name' must be provided, but not both"
+  default     = null
+}
+
+variable "transit_gateway_component_name" {
+  type        = string
+  description = "The name of a Transit Gateway component to attach the Network Firewall to. Either 'vpc_component_name' or 'transit_gateway_component_name' must be provided, but not both"
+  default     = null
+
+  validation {
+    condition     = var.transit_gateway_component_name == null || can(regex("^[a-zA-Z0-9-_]+$", var.transit_gateway_component_name))
+    error_message = "The transit_gateway_component_name must contain only alphanumeric characters, hyphens, and underscores."
+  }
 }
 
 variable "network_firewall_name" {
@@ -108,6 +120,17 @@ variable "alert_logs_bucket_component_name" {
 
 variable "firewall_subnet_name" {
   type        = string
-  description = "Firewall subnet name"
+  description = "Firewall subnet name. Required when using 'vpc_component_name', not used when using 'transit_gateway_component_name'"
   default     = "firewall"
+}
+
+variable "deployment_mode" {
+  type        = string
+  description = "Deployment mode for the Network Firewall. Valid values: 'vpc' or 'transit_gateway'"
+  default     = null
+
+  validation {
+    condition     = var.deployment_mode == null || contains(["vpc", "transit_gateway"], var.deployment_mode)
+    error_message = "The deployment_mode must be either 'vpc' or 'transit_gateway'."
+  }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -13,11 +13,6 @@ variable "transit_gateway_component_name" {
   type        = string
   description = "The name of a Transit Gateway component to attach the Network Firewall to. Either 'vpc_component_name' or 'transit_gateway_component_name' must be provided, but not both"
   default     = null
-
-  validation {
-    condition     = var.transit_gateway_component_name == null || can(regex("^[a-zA-Z0-9-_]+$", var.transit_gateway_component_name))
-    error_message = "The transit_gateway_component_name must contain only alphanumeric characters, hyphens, and underscores."
-  }
 }
 
 variable "network_firewall_name" {

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -3,8 +3,10 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      source = "hashicorp/aws"
+      # The `transit_gateway_id` parameter has been released in AWS provider version 6.5.0 (released July 24, 2025).
+      # https://github.com/hashicorp/terraform-provider-aws/blob/v6.5.0/CHANGELOG.md
+      version = ">= 6.5.0"
     }
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,5 +8,9 @@ terraform {
       # https://github.com/hashicorp/terraform-provider-aws/blob/v6.5.0/CHANGELOG.md
       version = ">= 6.5.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
   }
 }


### PR DESCRIPTION
## what

- Add Transit Gateway (TGW) deployment mode support for AWS Network Firewall
- Upgrade `cloudposse/network-firewall/aws` module from `0.3.2` to `1.0.1`
- Update AWS provider requirement to `>= 6.5.0` to support Transit Gateway native integration
- Add `transit_gateway_component_name` variable for TGW mode deployment
- Add `availability_zone_ids` variable with smart auto-lookup capability
- Add deployment mode detection and validation logic (VPC vs TGW)
- Make VPC component optional (only required in VPC mode, not needed in TGW mode)
- Add comprehensive error handling and validation with helpful error messages
- Make component fully support both deployment architectures
- Add `null` provider to `versions.tf` for validation preconditions
- Fix AZ ID validation regex to correctly match AWS format (e.g., `use1-az1`, `usw2-az2`)
- Add defensive error handling in validation preconditions with `try()` wrappers

## why

- AWS Network Firewall now supports native integration with AWS Transit Gateway (announced June 2025)
- The `transit_gateway_id` parameter requires AWS provider version 6.5.0 or later (released July 24, 2025)
- Transit Gateway mode enables centralized security inspection without VPC attachment
- The initial module implementation (v1.0.0) was fixed in v1.0.1 to properly support TGW mode using `availability_zone_mapping` instead of `subnet_mapping`
- This is a **breaking change** due to the AWS provider version requirement bump from `>= 4.9.0, < 6.0.0` to `>= 6.5.0`

## features

### Dual Deployment Mode Support

**VPC Mode (existing):**
```yaml
vpc_component_name: "vpc"
firewall_subnet_name: "firewall"
# Uses subnet IDs from VPC component
```

**Transit Gateway Mode (new):**
```yaml
transit_gateway_component_name: "transit-gateway"
# availability_zone_ids: ["use1-az1", "use1-az2"]  # Optional - auto-detected if not specified
```

### Smart Availability Zone Auto-Lookup

- **Explicit mode**: Specify exact AZ IDs for full control
- **Automatic mode**: Leave empty to auto-select all available AZs in the region
- Automatically filters out local zones to ensure proper format
- Validates AZ ID format: `^[a-z]+[0-9]+-az[0-9]+[a-z]?$` (e.g., `use1-az1`, `usw2-az2`, `apse2-az3`)

### Comprehensive Validation & Error Handling

- Ensures exactly one of VPC or TGW mode is specified
- Validates subnet names exist in VPC mode with helpful error messages
- Validates AZ ID format when explicitly provided
- Safe error handling with `try()` wrappers on remote state lookups
- Defensive preconditions prevent cryptic Terraform errors

### Technical Improvements

- Added `null` provider declaration for `null_resource` validation
- Wrapped remote state map access with `try()` for graceful error handling
- Fixed AZ ID regex to match actual AWS format (was rejecting all valid IDs)
- Provider pinning validation compliance

## references

- Upstream module PR (initial): https://github.com/cloudposse/terraform-aws-network-firewall/pull/32
- Upstream module PR (fix): https://github.com/cloudposse/terraform-aws-network-firewall/pull/33
- Module release v1.0.1: https://github.com/cloudposse/terraform-aws-network-firewall/releases/tag/v1.0.1
- AWS provider release notes: https://github.com/hashicorp/terraform-provider-aws/blob/v6.5.0/CHANGELOG.md
- AWS announcement: https://aws.amazon.com/about-aws/whats-new/2025/06/aws-network-firewall-transit-gateway-native-integration/
- AWS documentation: https://docs.aws.amazon.com/network-firewall/latest/developerguide/tgw-firewall.html
- Terraform resource docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall#transit-gateway-attached-firewall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Transit Gateway deployment mode as an alternative to VPC mode for network firewall placement.
  * Automatic availability zone detection when AZs aren't provided in Transit Gateway mode.

* **Improvements**
  * Mode-specific outputs and wiring so only relevant networking outputs are exposed per mode.
  * Stronger configuration validation enforcing exactly one deployment mode and required inputs per mode.

* **Dependencies**
  * Updated AWS provider constraint and added Null provider support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->